### PR TITLE
allow errors to render via to_s

### DIFF
--- a/lib/errors/metadata_error.rb
+++ b/lib/errors/metadata_error.rb
@@ -9,4 +9,8 @@ class MetadataError < StandardError
     @file = file
     @problem = problem
   end
+
+  def to_s
+    problem.to_s
+  end
 end


### PR DESCRIPTION
Allows test output to go from:

1) Failure: DateTest#test_mods_checking [/home/mcritchlow/projects/ucsd/metadata-ci/test/date_test.rb:13]:
Expected [#<InvalidDate: InvalidDate>] to be empty.

To:

1) Failure: DateTest#test_csv_checking [/home/mcritchlow/projects/ucsd/metadata-ci/test/date_test.rb:34]:
Expected [#<InvalidDate: created_start on line 2: '1887' is not W3C-valid (https://www.w3.org/TR/1998/NOTE-datetime-19980827)] to be empty.